### PR TITLE
Fix the tool when querying boards with large card counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
         <label>Add blank column for notes<input type="checkbox" id="addNotesCheckbox" checked></label>
         <br/>
         <button id="generateButton">Generate</button>
+        <div id="progressMessage"></div>
 
         <div id="tables">
         </div>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
         <br/>
         <label>Add blank column for notes<input type="checkbox" id="addNotesCheckbox" checked></label>
         <br/>
+        <label>Only fetch 100 items per column<input type="checkbox" id="columnLimitCheckbox"></label>
+        <br/>
         <button id="generateButton">Generate</button>
         <div id="progressMessage"></div>
 

--- a/tables.js
+++ b/tables.js
@@ -322,10 +322,12 @@ function fetchGraphQLProjectData(columnCursor = null, cardCursor = null, project
             }
         }
         if (projectResponse.columns.nodes[0].cards.pageInfo.hasNextPage && !isColumnSizeLimited()) {
+            // get more cards for this column
             setProgressMessage('Fetching data for column ' + (project.columns.nodes.length) + '/' + projectResponse.columns.totalCount);
             return fetchGraphQLProjectData(columnCursor, projectResponse.columns.nodes[0].cards.pageInfo.endCursor, project);
         }
         if (projectResponse.columns.pageInfo.hasNextPage) {
+            // get the next column
             setProgressMessage('Fetching data for column ' + (project.columns.nodes.length + 1) + '/' + projectResponse.columns.totalCount);
             return fetchGraphQLProjectData(projectResponse.columns.pageInfo.endCursor, null, project);
         }

--- a/tables.js
+++ b/tables.js
@@ -27,6 +27,7 @@ function checkForJsonErrors(json) {
 }
 
 function generateTables() {
+    setButtonDisabledState(true);
     setProgressMessage('Fetching data');
     fetchGraphQLProjectData()
     .then((project) => {
@@ -57,6 +58,7 @@ function generateTables() {
         alert("An error occurred when processing:\n" + error);
     })
     .then(() => {
+        setButtonDisabledState(false);
         setProgressMessage('');
     });
 }
@@ -194,6 +196,10 @@ function getProjectName() {
 
 function getAddNotesColumn() {
     return document.getElementById('addNotesCheckbox').checked;
+}
+
+function setButtonDisabledState(disabled) {
+    document.getElementById('generateButton').disabled = disabled;
 }
 
 function setProgressMessage(message) {

--- a/tables.js
+++ b/tables.js
@@ -27,6 +27,7 @@ function checkForJsonErrors(json) {
 }
 
 function generateTables() {
+    setProgressMessage('Fetching data');
     fetchGraphQLProjectData()
     .then((project) => {
         clearTables();
@@ -54,6 +55,9 @@ function generateTables() {
     .catch(error => {
         console.error(error);
         alert("An error occurred when processing:\n" + error);
+    })
+    .then(() => {
+        setProgressMessage('');
     });
 }
 
@@ -192,6 +196,10 @@ function getAddNotesColumn() {
     return document.getElementById('addNotesCheckbox').checked;
 }
 
+function setProgressMessage(message) {
+    document.getElementById('progressMessage').innerText = message;
+}
+
 function fetchGraphQLProjectData(columnCursor = null, cardCursor = null, project = {columns:{nodes:[]}}) {
     const query =
 `query ($organisation_name: String!, $project_name: String, $column_cursor: String, $card_cursor: String) {
@@ -293,6 +301,7 @@ function fetchGraphQLProjectData(columnCursor = null, cardCursor = null, project
     .then(checkForJsonErrors)
     .then(json => json.data.organization.projects.nodes[0])
     .then(projectResponse => {
+        setProgressMessage('Fetching data for column ' + (project.columns.nodes.length + 1) + '/' + projectResponse.columns.totalCount);
         if (cardCursor === null) {
             // new column
             project.columns.nodes.push(projectResponse.columns.nodes[0])

--- a/tables.js
+++ b/tables.js
@@ -10,7 +10,7 @@ window.addEventListener('load', (event) => {
 function checkForHttpErrors(response) {
     if (response.status !== 200) {
         return response.text().then(text => {
-            throw `Unexpected response code ${response.status} - ${text}`
+            throw `Unexpected response code ${response.status} - ${text}`;
         });
     }
     return response;
@@ -123,7 +123,7 @@ function getPreviousColumn(issue) {
     if (issue.timelineItems == null) {
         return '** New Issue **';
     }
-    const events = issue.timelineItems.nodes
+    const events = issue.timelineItems.nodes;
     const targetTime = getPreviousColumnTargetDate();
 
     let latestChange = new Date(0);
@@ -314,11 +314,11 @@ function fetchGraphQLProjectData(columnCursor = null, cardCursor = null, project
     .then(projectResponse => {
         if (cardCursor === null) {
             // new column
-            project.columns.nodes.push(projectResponse.columns.nodes[0])
+            project.columns.nodes.push(projectResponse.columns.nodes[0]);
         } else {
             // add cards to current column
             for (let card of projectResponse.columns.nodes[0].cards.nodes) {
-                project.columns.nodes[project.columns.nodes.length - 1].cards.nodes.push(card)
+                project.columns.nodes[project.columns.nodes.length - 1].cards.nodes.push(card);
             }
         }
         if (projectResponse.columns.nodes[0].cards.pageInfo.hasNextPage && !isColumnSizeLimited()) {
@@ -329,6 +329,6 @@ function fetchGraphQLProjectData(columnCursor = null, cardCursor = null, project
             setProgressMessage('Fetching data for column ' + (project.columns.nodes.length + 1) + '/' + projectResponse.columns.totalCount);
             return fetchGraphQLProjectData(projectResponse.columns.pageInfo.endCursor, null, project);
         }
-        return project
+        return project;
     });
 }

--- a/tables.js
+++ b/tables.js
@@ -198,6 +198,11 @@ function getAddNotesColumn() {
     return document.getElementById('addNotesCheckbox').checked;
 }
 
+function isColumnSizeLimited() {
+    // This limits to 100, as that's the default (and maximum) cursor window size in github's graphql api
+    return document.getElementById('columnLimitCheckbox').checked;
+}
+
 function setButtonDisabledState(disabled) {
     document.getElementById('generateButton').disabled = disabled;
 }
@@ -316,7 +321,7 @@ function fetchGraphQLProjectData(columnCursor = null, cardCursor = null, project
                 project.columns.nodes[project.columns.nodes.length - 1].cards.nodes.push(card)
             }
         }
-        if (projectResponse.columns.nodes[0].cards.pageInfo.hasNextPage) {
+        if (projectResponse.columns.nodes[0].cards.pageInfo.hasNextPage && !isColumnSizeLimited()) {
             setProgressMessage('Fetching data for column ' + (project.columns.nodes.length) + '/' + projectResponse.columns.totalCount);
             return fetchGraphQLProjectData(columnCursor, projectResponse.columns.nodes[0].cards.pageInfo.endCursor, project);
         }

--- a/tables.js
+++ b/tables.js
@@ -307,7 +307,6 @@ function fetchGraphQLProjectData(columnCursor = null, cardCursor = null, project
     .then(checkForJsonErrors)
     .then(json => json.data.organization.projects.nodes[0])
     .then(projectResponse => {
-        setProgressMessage('Fetching data for column ' + (project.columns.nodes.length + 1) + '/' + projectResponse.columns.totalCount);
         if (cardCursor === null) {
             // new column
             project.columns.nodes.push(projectResponse.columns.nodes[0])
@@ -318,9 +317,11 @@ function fetchGraphQLProjectData(columnCursor = null, cardCursor = null, project
             }
         }
         if (projectResponse.columns.nodes[0].cards.pageInfo.hasNextPage) {
+            setProgressMessage('Fetching data for column ' + (project.columns.nodes.length) + '/' + projectResponse.columns.totalCount);
             return fetchGraphQLProjectData(columnCursor, projectResponse.columns.nodes[0].cards.pageInfo.endCursor, project);
         }
         if (projectResponse.columns.pageInfo.hasNextPage) {
+            setProgressMessage('Fetching data for column ' + (project.columns.nodes.length + 1) + '/' + projectResponse.columns.totalCount);
             return fetchGraphQLProjectData(projectResponse.columns.pageInfo.endCursor, null, project);
         }
         return project


### PR DESCRIPTION
Closes #3 

The GraphQL API was timing out when requesting the data for boards with larger numbers of cards.
To fix this I've modified the query to take cursors, basically pointers into the query, so rather than requesting the entire board, we instead retrieving batches of cards from one column at a time. By requesting smaller batches we reduce the time of each individual query, and avoid the timeout.

While splitting the query, I found that the graphql api uses cursors by default, with a maximum limit and default value on each set of nodes for 100. So previously even if a column had 300 cards, we'd only ever see 100. Using cursors now, we can get all of them. Should we not want such a wall of cards in the backlog table, I added a checkbox to prevent multiple calls being made on a single column, effectively using the old limited behaviour, but still using the column batching to prevent timeouts where there's a lot of columns with 100+ cards.

Since the query is now done in parts, I've also added a simple progress indicator to the UI.